### PR TITLE
Use the correct input type in calendar component

### DIFF
--- a/app/ui/components/rails_ui/calendar/component.html.erb
+++ b/app/ui/components/rails_ui/calendar/component.html.erb
@@ -1,6 +1,6 @@
 <%# app/components/rails_ui/calendar/component.html.erb %>
 <div class="w-full">
-  <input type="string"
+  <input type="text"
          id="<%= input_id %>"
          class="w-full rounded-md border bg-background px-3 py-2 text-sm shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-1 disabled:cursor-not-allowed disabled:opacity-50 border-border focus-visible:ring-ring placeholder:text-muted-foreground"
          placeholder="Select a date"


### PR DESCRIPTION
There's no such input type="string" , I guess you meant [input type="text"](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/text)